### PR TITLE
Add BaseURL path at the rendering phase

### DIFF
--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -1976,9 +1976,7 @@ func (s *Site) renderAndWritePage(name string, dest string, d interface{}, layou
 
 	transformLinks := transform.NewEmptyTransforms()
 
-	if viper.GetBool("RelativeURLs") || viper.GetBool("CanonifyURLs") {
-		transformLinks = append(transformLinks, transform.AbsURL)
-	}
+	transformLinks = append(transformLinks, transform.AbsURL)
 
 	if s.running() && viper.GetBool("watch") && !viper.GetBool("DisableLiveReload") {
 		transformLinks = append(transformLinks, transform.LiveReloadInject)
@@ -2005,6 +2003,13 @@ func (s *Site) renderAndWritePage(name string, dest string, d interface{}, layou
 			s += "/"
 		}
 		path = []byte(s)
+	} else {
+		permalink := helpers.MakePermalink(viper.GetString("BaseURL"), "")
+		permalink.Scheme = ""
+		permalink.Host = ""
+		permalink.User = nil
+		permalink.Opaque = ""
+		path = []byte(permalink.String())
 	}
 
 	transformer := transform.NewChain(transformLinks...)


### PR DESCRIPTION
I think your PR https://github.com/spf13/hugo/pull/2277 is good, but it's not working with `relativeURLs=false`. This PR tries to fix it.

It will add BaseURL path at the rendering phase when `RelativeURLs=false` and `CanonifyURLs=false`.
